### PR TITLE
fix: resolve ESLint errors

### DIFF
--- a/packages/keys/src/constants.ts
+++ b/packages/keys/src/constants.ts
@@ -13,8 +13,8 @@ export function detectPlatform(): 'mac' | 'windows' | 'linux' {
     return 'linux' // Default for SSR
   }
 
-  const platform = navigator.platform?.toLowerCase() ?? ''
-  const userAgent = navigator.userAgent?.toLowerCase() ?? ''
+  const platform = navigator.platform.toLowerCase()
+  const userAgent = navigator.userAgent.toLowerCase()
 
   if (platform.includes('mac') || userAgent.includes('mac')) {
     return 'mac'
@@ -310,7 +310,7 @@ export const KEY_DISPLAY_SYMBOLS: Record<string, string> = {
  * Canonical order for modifiers in normalized strings.
  * This ensures consistent output: Control+Alt+Shift+Meta+Key
  */
-export const MODIFIER_ORDER: CanonicalModifier[] = [
+export const MODIFIER_ORDER: Array<CanonicalModifier> = [
   'Control',
   'Alt',
   'Shift',

--- a/packages/keys/src/format.ts
+++ b/packages/keys/src/format.ts
@@ -1,4 +1,3 @@
-import type { FormatDisplayOptions, ParsedHotkey } from './types'
 import {
   KEY_DISPLAY_SYMBOLS,
   MAC_MODIFIER_SYMBOLS,
@@ -7,6 +6,7 @@ import {
   detectPlatform,
 } from './constants'
 import { parseHotkey } from './parse'
+import type { FormatDisplayOptions, ParsedHotkey } from './types'
 
 /**
  * Converts a ParsedHotkey back to a hotkey string.
@@ -21,7 +21,7 @@ import { parseHotkey } from './parse'
  * ```
  */
 export function formatHotkey(parsed: ParsedHotkey): string {
-  const parts: string[] = []
+  const parts: Array<string> = []
 
   // Add modifiers in canonical order
   for (const modifier of MODIFIER_ORDER) {
@@ -77,7 +77,7 @@ export function formatForDisplay(
  * Formats a hotkey for macOS display using symbols.
  */
 function formatForMac(parsed: ParsedHotkey): string {
-  const parts: string[] = []
+  const parts: Array<string> = []
 
   // Add modifiers in macOS order (typically Control, Option, Shift, Command)
   // But we'll use our canonical order and just use symbols
@@ -99,7 +99,7 @@ function formatForMac(parsed: ParsedHotkey): string {
  * Formats a hotkey for Windows/Linux display using text labels.
  */
 function formatForStandard(parsed: ParsedHotkey): string {
-  const parts: string[] = []
+  const parts: Array<string> = []
 
   // Add modifiers in canonical order
   for (const modifier of MODIFIER_ORDER) {
@@ -130,7 +130,7 @@ export function formatWithLabels(
 ): string {
   const parsed =
     typeof hotkey === 'string' ? parseHotkey(hotkey, platform) : hotkey
-  const parts: string[] = []
+  const parts: Array<string> = []
 
   // Custom labels for more readable output
   const labels: Record<string, string> = {

--- a/packages/keys/src/key-state.ts
+++ b/packages/keys/src/key-state.ts
@@ -8,7 +8,7 @@ export interface KeyStateTrackerState {
   /**
    * Array of currently held key names.
    */
-  heldKeys: string[]
+  heldKeys: Array<string>
 }
 
 /**
@@ -24,7 +24,7 @@ function getDefaultKeyStateTrackerState(): KeyStateTrackerState {
  * Listener function type for key state changes.
  * @deprecated Use `store.subscribe()` or `useStore()` from `@tanstack/react-store` instead.
  */
-export type KeyStateListener = (keys: string[]) => void
+export type KeyStateListener = (keys: Array<string>) => void
 
 /**
  * Singleton tracker for currently held keyboard keys.
@@ -175,7 +175,7 @@ export class KeyStateTracker {
    *
    * @returns Array of key names currently being pressed
    */
-  getHeldKeys(): string[] {
+  getHeldKeys(): Array<string> {
     return this.store.state.heldKeys
   }
 
@@ -196,7 +196,7 @@ export class KeyStateTracker {
    * @param keys - Array of key names to check
    * @returns True if any of the keys are currently held
    */
-  isAnyKeyHeld(keys: string[]): boolean {
+  isAnyKeyHeld(keys: Array<string>): boolean {
     return keys.some((key) => this.isKeyHeld(key))
   }
 
@@ -206,7 +206,7 @@ export class KeyStateTracker {
    * @param keys - Array of key names to check
    * @returns True if all of the keys are currently held
    */
-  areAllKeysHeld(keys: string[]): boolean {
+  areAllKeysHeld(keys: Array<string>): boolean {
     return keys.every((key) => this.isKeyHeld(key))
   }
 

--- a/packages/keys/src/manager.ts
+++ b/packages/keys/src/manager.ts
@@ -1,3 +1,6 @@
+import { detectPlatform } from './constants'
+import { parseHotkey } from './parse'
+import { matchesKeyboardEvent } from './match'
 import type {
   Hotkey,
   HotkeyCallback,
@@ -5,9 +8,6 @@ import type {
   HotkeyOptions,
   HotkeyRegistration,
 } from './types'
-import { detectPlatform } from './constants'
-import { parseHotkey } from './parse'
-import { matchesKeyboardEvent } from './match'
 
 let registrationIdCounter = 0
 

--- a/packages/keys/src/match.ts
+++ b/packages/keys/src/match.ts
@@ -1,11 +1,11 @@
+import { detectPlatform, normalizeKeyName } from './constants'
+import { parseHotkey } from './parse'
 import type {
   Hotkey,
   HotkeyCallback,
   HotkeyCallbackContext,
   ParsedHotkey,
 } from './types'
-import { detectPlatform, normalizeKeyName } from './constants'
-import { parseHotkey } from './parse'
 
 /**
  * Checks if a KeyboardEvent matches a hotkey.
@@ -150,7 +150,10 @@ export function createMultiHotkeyHandler(
   const resolvedPlatform = platform ?? detectPlatform()
 
   // Pre-parse all hotkeys for efficiency
-  const parsedHandlers = Object.entries(handlers)
+  const handlerEntries = Object.entries(handlers) as Array<
+    [string, HotkeyCallback | undefined]
+  >
+  const parsedHandlers = handlerEntries
     .filter(
       (entry): entry is [string, HotkeyCallback] => entry[1] !== undefined,
     )
@@ -184,7 +187,7 @@ export function createMultiHotkeyHandler(
  * Used internally to provide the hotkey string in callback context.
  */
 function formatParsedHotkey(parsed: ParsedHotkey): Hotkey {
-  const parts: string[] = []
+  const parts: Array<string> = []
 
   if (parsed.ctrl) parts.push('Control')
   if (parsed.alt) parts.push('Alt')

--- a/packages/keys/src/parse.ts
+++ b/packages/keys/src/parse.ts
@@ -1,4 +1,3 @@
-import type { CanonicalModifier, ParsedHotkey } from './types'
 import {
   MODIFIER_ALIASES,
   MODIFIER_ORDER,
@@ -6,6 +5,7 @@ import {
   normalizeKeyName,
   resolveModifier,
 } from './constants'
+import type { CanonicalModifier, ParsedHotkey } from './types'
 
 /**
  * Parses a hotkey string into its component parts.
@@ -93,7 +93,7 @@ export function normalizeHotkey(
   platform: 'mac' | 'windows' | 'linux' = detectPlatform(),
 ): string {
   const parsed = parseHotkey(hotkey, platform)
-  const parts: string[] = []
+  const parts: Array<string> = []
 
   // Add modifiers in canonical order
   for (const modifier of MODIFIER_ORDER) {

--- a/packages/keys/src/sequence.ts
+++ b/packages/keys/src/sequence.ts
@@ -1,3 +1,6 @@
+import { detectPlatform } from './constants'
+import { parseHotkey } from './parse'
+import { matchesKeyboardEvent } from './match'
 import type {
   Hotkey,
   HotkeyCallback,
@@ -6,9 +9,6 @@ import type {
   ParsedHotkey,
   SequenceOptions,
 } from './types'
-import { detectPlatform } from './constants'
-import { parseHotkey } from './parse'
-import { matchesKeyboardEvent } from './match'
 
 /**
  * Default timeout between keys in a sequence (in milliseconds).
@@ -30,7 +30,7 @@ function generateSequenceId(): string {
 interface SequenceRegistration {
   id: string
   sequence: HotkeySequence
-  parsedSequence: ParsedHotkey[]
+  parsedSequence: Array<ParsedHotkey>
   callback: HotkeyCallback
   options: SequenceOptions
   currentIndex: number

--- a/packages/keys/src/types.ts
+++ b/packages/keys/src/types.ts
@@ -235,7 +235,7 @@ export interface ParsedHotkey {
   /** Whether the Meta (Command) key is required */
   meta: boolean
   /** List of canonical modifier names that are required */
-  modifiers: CanonicalModifier[]
+  modifiers: Array<CanonicalModifier>
 }
 
 /**
@@ -253,9 +253,9 @@ export interface ValidationResult {
   /** Whether the hotkey is valid (can still have warnings) */
   valid: boolean
   /** Warning messages about potential issues */
-  warnings: string[]
+  warnings: Array<string>
   /** Error messages about invalid syntax */
-  errors: string[]
+  errors: Array<string>
 }
 
 // =============================================================================
@@ -327,7 +327,7 @@ export interface HotkeyOptions {
  * const deleteWord: HotkeySequence = ['D', 'I', 'W']  // diw
  * ```
  */
-export type HotkeySequence = Hotkey[]
+export type HotkeySequence = Array<Hotkey>
 
 /**
  * Options for hotkey sequence matching.

--- a/packages/keys/src/validate.ts
+++ b/packages/keys/src/validate.ts
@@ -1,4 +1,3 @@
-import type { ValidationResult } from './types'
 import {
   ALL_KEYS,
   LETTER_KEYS,
@@ -6,6 +5,7 @@ import {
   NUMBER_KEYS,
 } from './constants'
 import { parseHotkey } from './parse'
+import type { ValidationResult } from './types'
 
 /**
  * Validates a hotkey string and returns any warnings or errors.
@@ -35,8 +35,8 @@ import { parseHotkey } from './parse'
  * ```
  */
 export function validateHotkey(hotkey: string): ValidationResult {
-  const warnings: string[] = []
-  const errors: string[] = []
+  const warnings: Array<string> = []
+  const errors: Array<string> = []
 
   // Check for empty string
   if (!hotkey || hotkey.trim() === '') {


### PR DESCRIPTION
## 🎯 Changes

Fixed ESLint errors in  package.

- Fix import order
- Change array types from `T[]` to `Array<T>`
- Add explicit type assertion for `Object.entries` to preserve undefined possibility
- Remove unnecessary optional chaining on navigator properties

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/keys/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [x] This change is docs/CI/dev-only (no release).