### PR TITLE
feat(hotkeys): add numpad key support

### DIFF
--- a/.changeset/numpad-keys-support.md
+++ b/.changeset/numpad-keys-support.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/hotkeys': minor
+---
+
+Add numpad key support with NumpadKey type including Numpad0-9, NumpadAdd, NumpadSubtract, NumpadMultiply, NumpadDivide, NumpadDecimal, and NumpadEnter

--- a/packages/hotkeys/src/constants.ts
+++ b/packages/hotkeys/src/constants.ts
@@ -5,6 +5,7 @@ import type {
   LetterKey,
   NavigationKey,
   NumberKey,
+  NumpadKey,
   PunctuationKey,
 } from './hotkey'
 
@@ -299,6 +300,35 @@ export const PUNCTUATION_KEYS = new Set<PunctuationKey>([
 ])
 
 /**
+ * Set of all valid numpad keys.
+ *
+ * Numpad keys are commonly used for data entry and calculator-style input.
+ * They produce distinct `event.key` values from the main number row:
+ * - `Numpad0`-`Numpad9` for digits
+ * - `NumpadAdd`, `NumpadSubtract`, `NumpadMultiply`, `NumpadDivide` for operators
+ * - `NumpadDecimal` for the decimal point
+ * - `NumpadEnter` for the numpad enter key
+ */
+export const NUMPAD_KEYS = new Set<NumpadKey>([
+  'Numpad0',
+  'Numpad1',
+  'Numpad2',
+  'Numpad3',
+  'Numpad4',
+  'Numpad5',
+  'Numpad6',
+  'Numpad7',
+  'Numpad8',
+  'Numpad9',
+  'NumpadAdd',
+  'NumpadSubtract',
+  'NumpadMultiply',
+  'NumpadDivide',
+  'NumpadDecimal',
+  'NumpadEnter',
+])
+
+/**
  * Set of all valid non-modifier keys.
  *
  * This is the union of all key type sets (letters, numbers, function keys, navigation,
@@ -319,6 +349,7 @@ export const ALL_KEYS = new Set([
   ...NAVIGATION_KEYS,
   ...EDITING_KEYS,
   ...PUNCTUATION_KEYS,
+  ...NUMPAD_KEYS,
 ])
 
 /**
@@ -391,6 +422,24 @@ const KEY_ALIASES: Record<string, string> = {
   PgDn: 'PageDown',
   pgup: 'PageUp',
   pgdn: 'PageDown',
+
+  // Numpad variants (lowercase aliases)
+  numpad0: 'Numpad0',
+  numpad1: 'Numpad1',
+  numpad2: 'Numpad2',
+  numpad3: 'Numpad3',
+  numpad4: 'Numpad4',
+  numpad5: 'Numpad5',
+  numpad6: 'Numpad6',
+  numpad7: 'Numpad7',
+  numpad8: 'Numpad8',
+  numpad9: 'Numpad9',
+  numpadadd: 'NumpadAdd',
+  numpadsubtract: 'NumpadSubtract',
+  numpadmultiply: 'NumpadMultiply',
+  numpaddivide: 'NumpadDivide',
+  numpaddecimal: 'NumpadDecimal',
+  numpadenter: 'NumpadEnter',
 }
 
 /**

--- a/packages/hotkeys/src/hotkey.ts
+++ b/packages/hotkeys/src/hotkey.ts
@@ -126,6 +126,28 @@ export type PunctuationKey =
   | '`'
 
 /**
+ * Numpad keys for numeric keypad operations.
+ * These keys are commonly used for data entry and calculator-style input.
+ */
+export type NumpadKey =
+  | 'Numpad0'
+  | 'Numpad1'
+  | 'Numpad2'
+  | 'Numpad3'
+  | 'Numpad4'
+  | 'Numpad5'
+  | 'Numpad6'
+  | 'Numpad7'
+  | 'Numpad8'
+  | 'Numpad9'
+  | 'NumpadAdd'
+  | 'NumpadSubtract'
+  | 'NumpadMultiply'
+  | 'NumpadDivide'
+  | 'NumpadDecimal'
+  | 'NumpadEnter'
+
+/**
  * Keys that don't change their value when Shift is pressed.
  * These keys produce the same `KeyboardEvent.key` value whether Shift is held or not.
  *
@@ -141,6 +163,7 @@ type NonPunctuationKey =
   | EditingKey
   | NavigationKey
   | FunctionKey
+  | NumpadKey
 
 /**
  * All supported non-modifier keys.


### PR DESCRIPTION
## Summary
Add type-safe support for numpad keys, enabling autocomplete for shortcuts like `Mod+Numpad1` or `NumpadEnter`.

## 🎯 Changes
- Add `NumpadKey` type with 16 numpad keys: `Numpad0`-`Numpad9`, `NumpadAdd`, `NumpadSubtract`, `NumpadMultiply`, `NumpadDivide`, `NumpadDecimal`, `NumpadEnter`
- Add `NUMPAD_KEYS` constant set for validation
- Include numpad keys in `ALL_KEYS` union
- Add `NumpadKey` to `NonPunctuationKey` for proper Shift combination typing

## Use Cases
- Professional apps (accounting, 3D modeling like Blender)
- Data entry applications
- Gaming shortcuts
- Accessibility (one-handed numpad operation)
