### PR TITLE
fix(hotkeys): recognize contenteditable="plaintext-only" in isInputElement

### DIFF
--- a/.changeset/fix-is-input-element-plaintext-only.md
+++ b/.changeset/fix-is-input-element-plaintext-only.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/hotkeys': patch
+---
+
+fix(isInputElement): recognize contenteditable="plaintext-only" and inherited contenteditable

--- a/packages/hotkeys/src/manager.utils.ts
+++ b/packages/hotkeys/src/manager.utils.ts
@@ -65,12 +65,10 @@ export function isInputElement(element: EventTarget | null): boolean {
     return true
   }
 
-  // Check for contenteditable elements
-  if (element instanceof HTMLElement) {
-    const contentEditable = element.contentEditable
-    if (contentEditable === 'true' || contentEditable === '') {
-      return true
-    }
+  // Check for contenteditable elements (includes "true", "", "plaintext-only",
+  // and inherited contenteditable from ancestor elements)
+  if (element instanceof HTMLElement && element.isContentEditable) {
+    return true
   }
 
   return false

--- a/packages/hotkeys/tests/manager.utils.test.ts
+++ b/packages/hotkeys/tests/manager.utils.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
 import {
   defaultHotkeyOptions,
   getDefaultIgnoreInputs,
@@ -51,6 +52,22 @@ describe('manager.utils', () => {
       const div = document.createElement('div')
       div.contentEditable = 'true'
       expect(isInputElement(div)).toBe(true)
+    })
+
+    it('should return true for contenteditable plaintext-only elements', () => {
+      const div = document.createElement('div')
+      div.contentEditable = 'plaintext-only'
+      expect(isInputElement(div)).toBe(true)
+    })
+
+    it('should return true for inherited contenteditable', () => {
+      const parent = document.createElement('div')
+      parent.contentEditable = 'true'
+      const child = document.createElement('span')
+      parent.appendChild(child)
+      document.body.appendChild(parent)
+      expect(isInputElement(child)).toBe(true)
+      document.body.removeChild(parent)
     })
 
     it('should return false for contenteditable false', () => {


### PR DESCRIPTION
Closes #50

## Summary

`isInputElement()` previously checked `element.contentEditable` against `'true'` and `''`, missing `'plaintext-only'` and inherited contenteditable. This caused hotkeys with `ignoreInputs: true` (the default for single keys like Backspace/Delete) to fire while typing in `contenteditable="plaintext-only"` elements.

Replaced the string comparison with `element.isContentEditable`, a computed boolean that covers all editable states:
- `contenteditable="true"`
- `contenteditable=""`
- `contenteditable="plaintext-only"`
- Inherited contenteditable from ancestor elements

## Test plan

- Added test: `contenteditable="plaintext-only"` element is recognized as input
- Added test: child element inheriting contenteditable from parent is recognized as input
- All 277 existing tests pass

Made with [Cursor](https://cursor.com)