### PR TITLE
docs: add svelte installation links

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,6 +12,7 @@ lit: @tanstack/lit-hotkeys
 preact: @tanstack/preact-hotkeys
 react: @tanstack/react-hotkeys
 solid: @tanstack/solid-hotkeys
+svelte: @tanstack/svelte-hotkeys
 vue: @tanstack/vue-hotkeys
 
 <!-- ::end:tabs -->
@@ -42,6 +43,14 @@ Start with the [API reference](./framework/preact/reference/index) and [guides](
 # Solid
 
 Start with the [API reference](./framework/solid/reference/index) and [guides](./framework/solid/guides/hotkeys). If you want the integrated devtools panel, also install:
+
+<!-- ::end:framework -->
+
+<!-- ::start:framework -->
+
+# Svelte
+
+Start with the [Quick Start](./framework/svelte/quick-start) guide and the Svelte-specific [guides](./framework/svelte/guides/hotkeys).
 
 <!-- ::end:framework -->
 


### PR DESCRIPTION
## 🎯 Changes

Add Svelte framework to the installation docs — tab entry and quick start section with links to guides.                                                                                                          

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/hotkeys/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Svelte as a supported framework in the installation documentation with package installation information.
  * Created a dedicated Svelte section with links to Quick Start and Svelte-specific hotkeys guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->