### PR TITLE
fix: register KeyStateTracker in capture phase

### DIFF
--- a/.changeset/key-state-tracker-capture-phase.md
+++ b/.changeset/key-state-tracker-capture-phase.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/hotkeys': patch
+---
+
+Register KeyStateTracker listeners in capture phase so held-key state stays accurate while a HotkeyRecorder / HotkeySequenceRecorder is active.

--- a/packages/hotkeys/src/key-state-tracker.ts
+++ b/packages/hotkeys/src/key-state-tracker.ts
@@ -150,8 +150,8 @@ export class KeyStateTracker {
       }
     }
 
-    document.addEventListener('keydown', this.#keydownListener)
-    document.addEventListener('keyup', this.#keyupListener)
+    document.addEventListener('keydown', this.#keydownListener, true)
+    document.addEventListener('keyup', this.#keyupListener, true)
     window.addEventListener('blur', this.#blurListener)
   }
 
@@ -174,12 +174,12 @@ export class KeyStateTracker {
     }
 
     if (this.#keydownListener) {
-      document.removeEventListener('keydown', this.#keydownListener)
+      document.removeEventListener('keydown', this.#keydownListener, true)
       this.#keydownListener = null
     }
 
     if (this.#keyupListener) {
-      document.removeEventListener('keyup', this.#keyupListener)
+      document.removeEventListener('keyup', this.#keyupListener, true)
       this.#keyupListener = null
     }
 

--- a/packages/hotkeys/tests/key-state-tracker.test.ts
+++ b/packages/hotkeys/tests/key-state-tracker.test.ts
@@ -1,5 +1,6 @@
 /// <reference lib="dom" />
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { HotkeySequenceRecorder } from '../src/hotkey-sequence-recorder'
 import { KeyStateTracker } from '../src/key-state-tracker'
 
 /**
@@ -273,6 +274,37 @@ describe('KeyStateTracker', () => {
       dispatchKey('keydown', 'a')
       expect(tracker.isKeyHeld('a')).toBe(true)
       expect(tracker.isKeyHeld('A')).toBe(true)
+    })
+  })
+
+  describe('capture phase registration', () => {
+    // Regression: a HotkeySequenceRecorder registers a capture-phase keydown
+    // listener that calls stopPropagation. If the tracker is on the bubble
+    // phase, propagation halts before its listener runs and held-key state
+    // goes stale. Capture-phase registration ensures the tracker observes
+    // every key, even when a recorder is active.
+    it('tracks held keys while a HotkeySequenceRecorder is active', () => {
+      const tracker = KeyStateTracker.getInstance()
+      const recorder = new HotkeySequenceRecorder({ onRecord: () => {} })
+      recorder.start()
+
+      const child = document.createElement('div')
+      document.body.appendChild(child)
+
+      try {
+        child.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'Control',
+            code: 'ControlLeft',
+            bubbles: true,
+          }),
+        )
+
+        expect(tracker.getHeldKeys()).toContain('Control')
+      } finally {
+        recorder.destroy()
+        child.remove()
+      }
     })
   })
 })


### PR DESCRIPTION
## 🎯 Changes

Closes #114.

`KeyStateTracker` registered its `keydown`/`keyup` listeners on the bubble phase, so while a `HotkeyRecorder` or `HotkeySequenceRecorder` was active its capture-phase `stopPropagation()` halted the event before the tracker could observe it. Held-key state went stale for the duration of recording, breaking `getHeldKeys()` and every framework adapter on top of it.

This switches the tracker to capture phase (matching the recorders) so it sees every key before any downstream listener can stop propagation. The tracker only reads `event.key`/`event.code` and never calls `preventDefault`/`stopPropagation`, so the phase change has no other observable effect. Scope is limited to `@tanstack/hotkeys` — all framework adapters subscribe to the same singleton store and pick the fix up transitively.

```diff
- document.addEventListener('keydown', this.#keydownListener)
- document.addEventListener('keyup', this.#keyupListener)
+ document.addEventListener('keydown', this.#keydownListener, true)
+ document.addEventListener('keyup', this.#keyupListener, true)
```

(Matching change in `#removeListeners()`.)

### Tests

Added a regression test in `packages/hotkeys/tests/key-state-tracker.test.ts` that starts a `HotkeySequenceRecorder` and dispatches a `keydown` from a child element. Pre-fix `heldKeys` is `[]`; post-fix it contains `Control`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/hotkeys/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `KeyStateTracker` to accurately capture held-key state while a hotkey recorder is active.

* **Tests**
  * Added regression test for key state tracking behavior with hotkey recorders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->