### PR TITLE
fix(react-hotkeys): set hotkey options after ui commit #113

### DIFF
--- a/.changeset/tangy-clubs-divide.md
+++ b/.changeset/tangy-clubs-divide.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-hotkeys': patch
+---
+
+Fixed `useHotkey` updating registration options during the render phase. Options are now synced in an effect after the UI commits, so store subscribers (like `useHotkeyRegistrations`) are no longer notified mid-render, which could trigger React warnings and inconsistent state. Fixes #113.

--- a/packages/react-hotkeys/src/useHotkey.ts
+++ b/packages/react-hotkeys/src/useHotkey.ts
@@ -178,10 +178,17 @@ export function useHotkey(
     }
   }, [hotkeyString])
 
-  // Sync callback and options on EVERY render (outside useEffect)
+  // Sync callback on EVERY render (outside useEffect)
   // This avoids stale closures - the callback always has access to latest state
   if (registrationRef.current?.isActive) {
     registrationRef.current.callback = callback
-    registrationRef.current.setOptions(optionsWithoutTarget)
   }
+
+  // Sync options after the UI commits so store subscribers aren't
+  // notified during the render phase
+  useEffect(() => {
+    if (registrationRef.current?.isActive) {
+      registrationRef.current.setOptions(optionsWithoutTarget)
+    }
+  })
 }

--- a/packages/react-hotkeys/tests/useHotkey.test.tsx
+++ b/packages/react-hotkeys/tests/useHotkey.test.tsx
@@ -257,3 +257,31 @@ describe('useHotkey', () => {
     })
   })
 })
+
+describe('options sync timing', () => {
+  it('should notify store subscribers after commit, not during render', () => {
+    const manager = HotkeyManager.getInstance()
+    const timeline: Array<string> = []
+
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => {
+        timeline.push('render-start')
+        useHotkey('Mod+S', () => {}, { platform: 'mac', enabled })
+        timeline.push('render-end')
+      },
+      { initialProps: { enabled: true } },
+    )
+
+   const subscribe =  manager.registrations.subscribe(() => {
+      timeline.push('store-notified')
+    })
+
+    timeline.length = 0;
+    rerender({ enabled: false })
+
+    expect(timeline).toEqual(['render-start', 'render-end', 'store-notified'])
+
+    subscribe.unsubscribe();
+    });
+  });
+


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->
This PR prevent UseHotkey from emitting store state changes in mid render. Previously on every rerender the Hotkey Register options were set with SetOptions during the render body. The problem is that store subscribers like useHotkeyRegistrations would receive store update mid render. This would causes yet another rerender while react was rending already.  By applying useEffect to setOptions we now wait till the component using UseHotkey has committed its ui changes  before triggering a store update. 


Issue:
#113 

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/hotkeys/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hotkey option synchronization so updates happen after UI rendering commits, avoiding React warnings and inconsistent state.
  * Ensured hotkey registration subscribers are notified at the correct time when hotkey options change.
* **Tests**
  * Added coverage that verifies the notification order across render, commit, and hotkey store updates when toggling hotkey options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->